### PR TITLE
fix: updating readme and plugin definition to comply with Wordpress naming conventions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,10 +1,10 @@
-=== Open edX WooCommerce Plugin ===
+=== Open edX Ecommerce ===
 Contributors: felipemontoya, julianrg2, mafermazu
-Tags: openedx, open edx, woocommerce, lms, courses
+Tags: openedx, open edx, ecommerce, lms, courses
 Requires at least: 6.3
 Tested up to: 6.3.1
 Requires PHP: 8.0
-Stable tag: 1.14.1
+Stable tag: 1.14.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,7 @@ You can sell your Open edX courses with WooCommerce using this free and open-sou
 
 == Description ==
 
-The "Open edX WooCommerce Plugin" is a free and open-source WordPress plugin that allows you to integrate WooCommerce with your Open edX platform.
+The "Open edX Ecommerce" package is a free and open-source WordPress plugin that allows you to integrate WooCommerce with your Open edX platform.
 
 **What does this mean?**
 You can create Open edX courses as products in WooCommerce, and when you perform purchase or refund operations for these products, your Open edX platform will reflect these changes.
@@ -50,7 +50,7 @@ Below are some links to help you get started with Open edX WooCommerce Plugin:
 
 = Manual installation =
 
-- Download the ZIP version in our [GitHub repository](https://github.com/eduNEXT/openedx-woocommerce-plugin/releases).
+- Download the ZIP version in our [GitHub repository](https://github.com/eduNEXT/openedx-wordpress-ecommerce/releases).
 
 <img src="https://i.ibb.co/YTSLYf4/zip-from-release.png" alt="Download ZIP from release">
 
@@ -64,7 +64,7 @@ If you need help setting up and configuring this plugin, visit the [documentatio
 
 = Where can I report bugs or request features? =
 
-Report bugs and request features on the [GitHub repository](https://github.com/eduNEXT/openedx-woocommerce-plugin/issues).
+Report bugs and request features on the [GitHub repository](https://github.com/eduNEXT/openedx-wordpress-ecommerce/issues).
 
 = Can I contribute? =
 
@@ -76,4 +76,4 @@ This project accepts all contributions, bug fixes, security fixes, maintenance w
 
 == Changelog ==
 
-You can find the [Changelog in the GitHub repository.](https://github.com/eduNEXT/openedx-woocommerce-plugin/blob/main/CHANGELOG.md)
+You can find the [Changelog in the GitHub repository.](https://github.com/eduNEXT/openedx-wordpress-ecommerce/blob/main/CHANGELOG.md)

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: openedx, open edx, ecommerce, lms, courses
 Requires at least: 6.3
 Tested up to: 6.3.1
 Requires PHP: 8.0
-Stable tag: 1.14.0
+Stable tag: 1.14.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/openedx-ecommerce.php
+++ b/openedx-ecommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Open edX Ecommerce
  * Plugin URI:        https://github.com/eduNEXT/openedx-wordpress-ecommerce
  * Description:       Easily connect your WooCommerce store to Open edX.
- * Version:           1.14.0
+ * Version:           1.14.1
  * Author:            eduNEXT
  * Author URI:        https://edunext.co/
  * License:           GPL-2.0+
@@ -32,7 +32,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', '1.14.0' );
+define( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', '1.14.1' );
 
 /**
  * The code that runs during plugin activation.

--- a/openedx-ecommerce.php
+++ b/openedx-ecommerce.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Plugin Name:       Open edX WooCommerce Plugin
- * Plugin URI:        https://github.com/eduNEXT/openedx-woocommerce-plugin
+ * Plugin Name:       Open edX Ecommerce
+ * Plugin URI:        https://github.com/eduNEXT/openedx-wordpress-ecommerce
  * Description:       Easily connect your WooCommerce store to Open edX.
- * Version:           1.14.1
+ * Version:           1.14.0
  * Author:            eduNEXT
  * Author URI:        https://edunext.co/
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:       openedx-woocommerce-plugin
+ * Text Domain:       openedx-ecommerce
  * Domain Path:       /languages
  * Requires at least: 6.3
  * Requires PHP: 8.0
@@ -32,7 +32,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', '1.14.1' );
+define( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', '1.14.0' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION

## Description
This PR updates the name of the plugin since uploading it to the wordpress registry had issues with the words "plugin" and "woocommerce" for trademark and internal wordpress rules.


<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
