### PR TITLE
fix: corrected main file name in ci github workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,14 +30,14 @@ jobs:
         with:
           find: "Version: *[0-9.]*"
           replace: "Version:           ${{ steps.tag_version.outputs.new_version }}"
-          include: "openedx-woocommerce-plugin.php"
+          include: "openedx-ecommerce.php"
           
       - name: Update php file version - define statement
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "(define\\( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', ')([^']*)(.*);"
           replace: "define( 'OPENEDX_WOOCOMMERCE_PLUGIN_VERSION', '${{ steps.tag_version.outputs.new_version }}' );"
-          include: "openedx-woocommerce-plugin.php"
+          include: "openedx-ecommerce.php"
           
       - name: Update README version
         uses: jacobtomlinson/gha-find-replace@v3
@@ -60,7 +60,7 @@ jobs:
         with:
           branch: ${{ github.ref }}
           commit_message: "docs(bumpversion): ${{ steps.tag_version.outputs.previous_tag }} → ${{ steps.tag_version.outputs.new_tag }}"
-          file_pattern: README.txt CHANGELOG.md openedx-woocommerce-plugin.php
+          file_pattern: README.txt CHANGELOG.md openedx-ecommerce.php
           
   release:
     needs: bumpversion


### PR DESCRIPTION
## Description

This change resolves a conflict between the Continuous Integration workflow and the main file's new name, requiring the workflow to point to the new filename.

## Additional information

The CI Workflow is failing due to an out-of-date file name pattern.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits
