### PR TITLE
fix: added missing parameter to process enrollment force

### DIFF
--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -151,7 +151,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 
 				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, false, $access_token_string, $enrollment_action );
-				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, 'POST' );
+				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, self::API_ENROLLMENT, 'POST' );
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
 				$enrollment_allowed_request_body = $this->get_enrollment_allowed_body( $enrollment_data, $access_token_string, $enrollment_action );
@@ -181,7 +181,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 
 				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, false, $access_token_string, $enrollment_action );
-				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, 'POST' );
+				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, self::API_ENROLLMENT, 'POST' );
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
 				$enrollment_allowed_request_body = $this->get_enrollment_allowed_body( $enrollment_data, $access_token_string, $enrollment_action );


### PR DESCRIPTION
## Description

Fixed an error in the call to the enrollment_process function. The endpoint parameter was missing in the request so it was not being sent correctly.

## Testing instructions

To test this change simply enter an enrollment and perform an enrollment_request with the "force" box checked.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits